### PR TITLE
Make tests more robust

### DIFF
--- a/ci/pipelines/b-drats/pipeline.yml
+++ b/ci/pipelines/b-drats/pipeline.yml
@@ -11,7 +11,7 @@ vault_creds: &vault_creds
   role_id: ((vault/resource_credentials.role_id))
   secret_id: ((vault/resource_credentials.secret_id))
 
-attempts: &number_of_retries 2
+attempts: &number_of_retries 1
 
 groups:
   - name: test

--- a/ci/pipelines/b-drats/pipeline.yml
+++ b/ci/pipelines/b-drats/pipeline.yml
@@ -143,7 +143,7 @@ jobs:
         INCLUDE_DEPLOYMENT_TESTCASE: true
         INCLUDE_TRUNCATE_DB_BLOBSTORE_TESTCASE: true
         INCLUDE_CREDHUB_TESTCASE: true
-        TIMEOUT_IN_MINUTES: 2_880 #! 48h
+        TIMEOUT_IN_MINUTES: 1_440  #! 24h as this is the lifetime of a Toolsmith env
       output_mapping:
         config: b-drats-config
     - load_var: env-metadata
@@ -159,7 +159,7 @@ jobs:
       JUMPBOX_USER: ubuntu
       BBR_BINARY: bbr-binary-release/releases/bbr
       SSH_ALIVE_INTERVAL: 60 #! in seconds
-      GINKGO_TIMEOUT: 48h0m0s #! 48h to be consistent with TIMEOUT_IN_MINUTES in the b-drats test config from the previous task.
+      GINKGO_TIMEOUT: 24h0m0s #! 48h to be consistent with TIMEOUT_IN_MINUTES in the b-drats test config from the previous task.
     input_mapping:
       bbr-binary-release: bbr-artefacts
       bosh-disaster-recovery-acceptance-tests: bosh-disaster-recovery-acceptance-tests-prs

--- a/fixtures/helpers.go
+++ b/fixtures/helpers.go
@@ -3,7 +3,11 @@ package fixtures
 import (
 	"path"
 	"runtime"
+  "time"
 )
+
+var EventuallyTimeout = 10 * time.Minute
+var EventuallyRetryInterval = 30 * time.Second
 
 func Path(relativePath string) string {
 	return path.Join(currentTestDir(), "../fixtures", relativePath)

--- a/runner/serial_runner.go
+++ b/runner/serial_runner.go
@@ -6,6 +6,7 @@ import (
 
 	"os"
 
+	"github.com/cloudfoundry-incubator/bosh-disaster-recovery-acceptance-tests/fixtures"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -100,7 +101,7 @@ func RunBoshDisasterRecoveryAcceptanceTestsSerially(config Config, testCases []T
 				By("waiting for bosh director api to be available", func() {
 					Eventually(func() int {
 						return RunBoshCommand("bosh releases", config, "releases").ExitCode()
-					}, "60s", "1s").Should(BeZero())
+					}, fixtures.EventuallyTimeout, fixtures.EventuallyRetryInterval).Should(BeZero())
 				})
 
 				By("running the after restore step", func() {

--- a/testcases/support.go
+++ b/testcases/support.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+
+	"github.com/cloudfoundry-incubator/bosh-disaster-recovery-acceptance-tests/fixtures"
 	. "github.com/cloudfoundry-incubator/bosh-disaster-recovery-acceptance-tests/runner"
 	. "github.com/onsi/gomega"
 )
@@ -23,7 +25,7 @@ func monitWait(config Config, jobName, status string) {
 			}
 		}
 		return ""
-	}, 5*time.Minute, time.Second).Should(HaveSuffix(status))
+	}, fixtures.EventuallyTimeout, fixtures.EventuallyRetryInterval).Should(HaveSuffix(status))
 }
 
 func monitStop(config Config, jobName string) {

--- a/testcases/truncate_db_blobstore_testcase.go
+++ b/testcases/truncate_db_blobstore_testcase.go
@@ -94,14 +94,16 @@ func (t TruncateDBBlobstoreTestcase) AfterRestore(config Config) {
 	})
 
 	By("validate deployment instances are back", func() {
-		session := RunBoshCommandSuccessfullyWithFailureMessage("bosh get sdk instances",
-			config,
-			"-n",
-			"-d",
-			"small-deployment",
-			"instances",
-		)
-		Expect(string(session.Out.Contents())).To(MatchRegexp("small-job/[a-z0-9-]+[ \t]+running"))
+    Eventually(func() string {
+      session := RunBoshCommandSuccessfullyWithFailureMessage("bosh get sdk instances",
+        config,
+        "-n",
+        "-d",
+        "small-deployment",
+        "instances",
+      )
+      return string(session.Out.Contents())
+    }, fixtures.EventuallyTimeout, fixtures.EventuallyRetryInterval).Should(MatchRegexp("small-job/[a-z0-9-]+[ \t]+running"))
 	})
 }
 


### PR DESCRIPTION
Since we migrated the pipeline to using Toolsmiths envs, our tests have gone flaky.

I believe this is because Toolsmiths envs are under capacity as they are optimised for reducing IaaS consumption.

This attempts to make our tests more reliable by:
- increasing timeouts used in assertions
- using more eventual assertions