### PR TITLE
Use assumed role for accessing BBR artefacts

### DIFF
--- a/ci/pipelines/b-drats/pipeline.yml
+++ b/ci/pipelines/b-drats/pipeline.yml
@@ -56,8 +56,9 @@ resources:
     bucket: bosh-backup-and-restore-builds
     region_name: eu-west-1
     regexp: bbr-(.*)\.tar
-    access_key_id: ((aws_credentials.access_key_id))
-    secret_access_key: ((aws_credentials.secret_access_key))
+    access_key_id: ((aws_credentials.cg_access_key_id))
+    secret_access_key: ((aws_credentials.cg_secret_access_key))
+    aws_role_arn: ((aws_credentials.cg_assumed_role_arn))
 
 - name: jammy-stemcell
   type: bosh-io-stemcell


### PR DESCRIPTION
Internal plumbing configuration change

(https://github.com/cloudfoundry/bosh-deployment/blob/master/bbr.yml) to add a backup job and properties where appropriate?