### PR TITLE
re-enable truncate-db-testcase

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -1,12 +1,13 @@
 package acceptance_test
 
 import (
+	"log"
+	"os"
+
 	"github.com/cloudfoundry-incubator/bosh-disaster-recovery-acceptance-tests/runner"
 	"github.com/cloudfoundry-incubator/bosh-disaster-recovery-acceptance-tests/testcases"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"log"
-	"os"
 )
 
 var _ = Describe("backing up bosh", Ordered, func() {
@@ -16,7 +17,7 @@ var _ = Describe("backing up bosh", Ordered, func() {
 
 	testCases := []runner.TestCase{
 		testcases.DeploymentTestcase{},
-		//testcases.TruncateDBBlobstoreTestcase{},
+		testcases.TruncateDBBlobstoreTestcase{},
 		testcases.CredhubTestcase{},
 	}
 

--- a/acceptance/config.go
+++ b/acceptance/config.go
@@ -21,6 +21,10 @@ type IntegrationConfig struct {
 	DeploymentAZ        string `json:"deployment_az"`
 	StemcellSrc         string `json:"stemcell_src"`
 	DeployJumpbox       bool   `json:"deploy_jumpbox"`
+	JumpboxHost         string `json:"jumpbox_host"`
+	JumpboxUser         string `json:"jumpbox_user"`
+	JumpboxPrivKey      string `json:"jumpbox_privkey"`
+	JumpboxPubKey       string `json:"jumpbox_pubkey"`
 }
 
 func (i IntegrationConfig) SSHPrivateKeyPath() (string, error) {

--- a/runner/command_line_helpers.go
+++ b/runner/command_line_helpers.go
@@ -14,7 +14,11 @@ import (
 )
 
 func RunBoshCommand(description string, config Config, args ...string) *gexec.Session {
-	return runCommandWithStream(description, GinkgoWriter, getBoshBaseCommand(config), args...)
+	return RunCommandWithStream(description, GinkgoWriter, getBoshBaseCommand(config), args...)
+}
+
+func RunBoshCommandViaSsh(description string, config Config, sshBaseCommand string, args ...string) *gexec.Session {
+	return RunCommandWithStream(description, GinkgoWriter, fmt.Sprintf("%s -c \"%s\"", sshBaseCommand, getBoshBaseCommand(config)), args...)
 }
 
 func RunBoshCommandSuccessfullyWithFailureMessage(description string, config Config, args ...string) *gexec.Session {
@@ -36,7 +40,7 @@ func RunBBRCommand(description string, config Config, args ...string) *gexec.Ses
 		return config.Jumpbox.RunBBR(description, config, args...)
 	}
 
-	return runCommandWithStream(description, os.Stdout, config.BBRBinaryPath, args...)
+	return RunCommandWithStream(description, os.Stdout, config.BBRBinaryPath, args...)
 }
 
 func RunBBRCommandSuccessfullyWithFailureMessage(description string, config Config, args ...string) {
@@ -45,7 +49,7 @@ func RunBBRCommandSuccessfullyWithFailureMessage(description string, config Conf
 }
 
 func RunCommandSuccessfullyWithFailureMessage(description string, writer io.Writer, cmd string, args ...string) *gexec.Session {
-	session := runCommandWithStream(description, writer, cmd, args...)
+	session := RunCommandWithStream(description, writer, cmd, args...)
 	Expect(session).To(gexec.Exit(0), "Command errored: "+description)
 	return session
 }
@@ -71,7 +75,7 @@ func runCommandWithStreamInDirectorVM(description string, writer io.Writer, conf
 	return session
 }
 
-func runCommandWithStream(description string, writer io.Writer, cmd string, args ...string) *gexec.Session {
+func RunCommandWithStream(description string, writer io.Writer, cmd string, args ...string) *gexec.Session {
 	cmdToRunArgs := strings.Join(args, " ")
 	cmdToRun := cmd + " " + cmdToRunArgs
 

--- a/runner/config.go
+++ b/runner/config.go
@@ -78,6 +78,16 @@ func NewConfig(integrationConfig acceptance.IntegrationConfig, bbrBinaryPath, ar
 			az:      defaultAZ,
 		}
 	}
+	if integrationConfig.JumpboxHost != "" && integrationConfig.JumpboxPrivKey != "" && integrationConfig.JumpboxUser != "" {
+		jb = &jumpbox{
+			network: defaultNetwork,
+			vmType:  defaultVMType,
+			az:      defaultAZ,
+			privkey: integrationConfig.JumpboxPrivKey,
+			host:    integrationConfig.JumpboxHost,
+			user:    integrationConfig.JumpboxUser,
+		}
+	}
 
 	return Config{
 		BOSH: BOSHConfig{

--- a/runner/jumpbox.go
+++ b/runner/jumpbox.go
@@ -2,13 +2,15 @@ package runner
 
 import (
 	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"text/template"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
-	"os"
-	"path"
-	"strings"
-	"text/template"
 )
 
 const deployment = "jumpbox"
@@ -22,19 +24,71 @@ type jumpbox struct {
 	network string
 	vmType  string
 	az      string
+	host    string
+	privkey string
+	user    string
+}
+
+func (j *jumpbox) HostIsSet() bool {
+	return j.host != ""
+}
+func (j *jumpbox) getSshBaseCommand() string {
+	keyPath, err := j.writeKeyFile()
+	if err != nil {
+		Fail("failed writing jumphost keyfile")
+	}
+	return fmt.Sprintf("ssh "+
+		"-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "+
+		"-i "+
+		"%s "+
+		"%s@%s ",
+		keyPath,
+		j.user,
+		j.host,
+	)
+}
+func (j *jumpbox) getScpBaseCommand(sourcePath, targetPath string) string {
+	keyPath, err := j.writeKeyFile()
+	if err != nil {
+		Fail("failed writing jumphost keyfile")
+	}
+	return fmt.Sprintf("scp "+
+		"-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "+
+		"-i %s "+
+		"%s "+
+		"%s@%s:%s ",
+		keyPath,
+		sourcePath,
+		j.user,
+		j.host,
+		targetPath,
+	)
 }
 
 func (j *jumpbox) Run(description string, config Config, args ...string) *gexec.Session {
 	if j == nil {
 		Fail("jumpbox not initialised")
 	}
-
-	params := []string{"-d", deployment, "ssh", "jumpbox", "--", "sudo"}
+	var params []string
+	if j.host != "" {
+		params = []string{"--", "sudo"}
+		params = append(params, strings.Split(strings.Join(args, " "), " ")...)
+		return RunCommandWithStream(description, GinkgoWriter, j.getSshBaseCommand(), params...)
+	}
+	params = []string{"-d", deployment, "ssh", "jumpbox", "--", "sudo"}
 	params = append(params, strings.Split(strings.Join(args, " "), " ")...)
 
 	return RunBoshCommand(description, config, params...)
 }
-
+func (j *jumpbox) writeKeyFile() (string, error) {
+	d, err := os.MkdirTemp("", "drats")
+	if err != nil {
+		return "", err
+	}
+	fname := filepath.Join(d, "key")
+	err = os.WriteFile(fname, []byte(j.privkey), 0400)
+	return fname, err
+}
 func (j *jumpbox) RunBBR(description string, config Config, args ...string) *gexec.Session {
 	args = append([]string{"/usr/local/bin/bbr"}, args...)
 	return j.Run(description, config, args...)
@@ -45,20 +99,27 @@ func (j *jumpbox) Deploy(config Config) {
 		GinkgoWriter.Println("Jumpbox not configured")
 		return
 	}
+	keyPath := path.Join("/tmp", path.Base(config.BOSH.SSHPrivateKeyPath))
+	if j.host == "" {
+		By("deploying a jumpbox")
+		RunBoshCommandSuccessfullyWithFailureMessage("deploying a jumpbox", config, "-n", "-d", deployment, "deploy", j.manifest())
+		By("copying across the BBR command")
+		RunBoshCommandSuccessfullyWithFailureMessage("copying across the BBR command", config, "-d", deployment, "scp", config.BBRBinaryPath, "jumpbox:/tmp/bbr")
 
-	By("deploying a jumpbox")
-	RunBoshCommandSuccessfullyWithFailureMessage("deploying a jumpbox", config, "-n", "-d", deployment, "deploy", j.manifest())
+		By("copying across the BOSH private key")
+		RunBoshCommandSuccessfullyWithFailureMessage("copying across the BOSH private key", config, "-d", deployment, "scp", config.BOSH.SSHPrivateKeyPath, fmt.Sprintf("jumpbox:%s", keyPath))
 
-	By("copying across the BBR command")
-	RunBoshCommandSuccessfullyWithFailureMessage("copying across the BBR command", config, "-d", deployment, "scp", config.BBRBinaryPath, "jumpbox:/tmp/bbr")
+	} else {
+		By("copying across the BBR command")
+		RunCommandWithStream("copying across the BBR command", os.Stdout, j.getScpBaseCommand(config.BBRBinaryPath, "/tmp/bbr"))
+		By("copying across the BOSH private key")
+		RunCommandWithStream("copying across the BBR command", os.Stdout, j.getScpBaseCommand(config.BOSH.SSHPrivateKeyPath, keyPath))
+	}
+
 	By("moving the BBR command into place")
 	j.Run("moving the BBR command into place", config, "mv", "/tmp/bbr", "/usr/local/bin/bbr")
 	By("Making the BBR command executable")
 	j.Run("Making the BBR command executable", config, "chmod", "+x", "/usr/local/bin/bbr")
-
-	keyPath := path.Join("/tmp", path.Base(config.BOSH.SSHPrivateKeyPath))
-	By("copying across the BOSH private key")
-	RunBoshCommandSuccessfullyWithFailureMessage("copying across the BOSH private key", config, "-d", deployment, "scp", config.BOSH.SSHPrivateKeyPath, fmt.Sprintf("jumpbox:%s", keyPath))
 	By("setting the correct permissions on the BOSH private key")
 	j.Run("setting the correct permissions on the BOSH private key", config, "chmod", "600", keyPath)
 }
@@ -68,9 +129,10 @@ func (j *jumpbox) Cleanup(config Config) {
 		GinkgoWriter.Println("Jumpbox cleanup not needed")
 		return
 	}
-
-	By("cleaning up the jumpbox")
-	RunBoshCommandSuccessfullyWithFailureMessage("cleaning up the jumpbox", config, "-n", "-d", deployment, "delete-deployment")
+	if j.host != "" {
+		By("cleaning up the jumpbox")
+		RunBoshCommandSuccessfullyWithFailureMessage("cleaning up the jumpbox", config, "-n", "-d", deployment, "delete-deployment")
+	}
 }
 
 func (j *jumpbox) manifest() string {


### PR DESCRIPTION
    [#186014099]

    when we moved the bdrats tests to runway, we added a jumpbox deployment
    where all the bbr commands are executed from. This required deploying
    a jumpbox via the available bosh. But since that jumpbox would be managed
    by the director that is getting backed up, some tests had to be deactivated
    because the test execution made the bosh unavailable to execute `bosh ssh`.

    This updates the tests to have a configurable jumphost (with provided ssh key).
    The actual jumphost is the opsman from the smith env that CI claims before
    running the tests.

    the option to deploy the jumpbox is kept in place in case of some downstream
    issue with this PR so were able to switch back quickly.