### PR TITLE
do not use shuttle

### DIFF
--- a/ci/pipelines/b-drats/pipeline.yml
+++ b/ci/pipelines/b-drats/pipeline.yml
@@ -156,14 +156,15 @@ jobs:
 - name: run-b-drats
   serial: true
   plan:
+  - get: env
+    trigger: true
+    passed:
+      - claim-env
   - in_parallel:
     - get: bosh-disaster-recovery-acceptance-tests-prs
       passed:
         - claim-env
-    - get: env
-      trigger: true
-      passed:
-        - claim-env
+
     - get: cryogenics-ci
     - get: jammy-stemcell
     - get: bbr-artefacts
@@ -171,6 +172,34 @@ jobs:
         unpack: true
     - get: image-cryogenics-essentials
     - get: image-backup-restore
+    #! This is here to improve the speed of running b-drats. Our env has TAS deployed. That adds 11gb of blobs to the blobstore. 
+    #! the tests deploy zookeeper and do not care about TAS but the existing TAS blobs have increased runtime from ~30m to over 3h
+    - task: bosh-clean-deployments
+      config: 
+        image_resource:
+          name: ""
+          source:
+            repository: harbor-repo.vmware.com/cryogenics/essentials
+          type: docker-image
+        inputs:
+        - name: env
+        platform: linux
+        run:
+          args:
+          - -c
+          - |
+            set -eu
+            set -o pipefail
+            source <( smith -l env/metadata bosh )
+             for ds in "$(bosh ds --json | jq .Tables[].Rows[].name -r)"; do
+               if [[ $ds == "" ]]; then
+                 continue
+               else
+                 bosh -d $ds delete-deployment -n
+               fi
+             done
+             bosh clean-up --all -n
+          path: bash
   - in_parallel:
     - put: bosh-disaster-recovery-acceptance-tests-prs
       params:

--- a/ci/tasks/run-b-drats/task.sh
+++ b/ci/tasks/run-b-drats/task.sh
@@ -2,33 +2,10 @@
 
 set -eu
 
-: "${JUMPBOX_IP:="$( terraform output -state terraform-state/terraform.tfstate jumpbox-ip | jq -r .)"}"
-: "${JUMPBOX_PRIVATE_KEY:="$( bosh interpolate --path /jumpbox_ssh/private_key "bosh-vars-store/${JUMPBOX_VARS_STORE_PATH}" )"}"
-: "${JUMPBOX_USER:?}"
 : "${BBR_BINARY:?}"
 : "${GINKGO_TIMEOUT:?}"
 
 export GINKGO_TIMEOUT
-
-jumpbox_private_key="$( mktemp )"
-echo -e "$JUMPBOX_PRIVATE_KEY" | sed -e 's/^"//' -e 's/"$//' > "$jumpbox_private_key"
-chmod 600 "$jumpbox_private_key"
-
-eval "$( ssh-agent )"
-ssh-add "$jumpbox_private_key"
-sshuttle -r "${JUMPBOX_USER}@${JUMPBOX_IP}" "10.0.0.0/16" -D --pidfile=sshuttle.pid -e "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ServerAliveInterval=${SSH_ALIVE_INTERVAL}" $SSHUTTLE_FLAGS
-sshuttle_pid="$( cat sshuttle.pid )"
-
-trap 'kill ${SSH_AGENT_PID}' EXIT
-
-sleep 5
-
-if ! stat sshuttle.pid > /dev/null 2>&1; then
-  echo "Failed to start sshuttle daemon"
-  exit 1
-fi
-
-trap 'kill ${sshuttle_pid}' EXIT
 
 GOPATH="$PWD"
 PATH="${PATH}:${GOPATH}/bin"
@@ -40,6 +17,29 @@ export GOPATH PATH INTEGRATION_CONFIG_PATH
 BBR_BINARY_PATH="$(ls ${PWD}/${BBR_BINARY})"
 chmod +x "$BBR_BINARY_PATH"
 export BBR_BINARY_PATH
+
+if cat $INTEGRATION_CONFIG_PATH | jq .jumpbox_host; then
+  USER=$( cat $INTEGRATION_CONFIG_PATH | jq .jumpbox_user -r )
+  HOST=$( cat $INTEGRATION_CONFIG_PATH | jq .jumpbox_host -r )
+  BOSH_HOST=$( cat $INTEGRATION_CONFIG_PATH | jq .bosh_host -r )
+  PK_PATH=$(mktemp)
+  echo -e "$( cat $INTEGRATION_CONFIG_PATH | jq .jumpbox_privkey -r)" > ${PK_PATH}
+
+  export CREDHUB_PROXY=ssh+socks5://${USER}@${HOST}:22?private-key=${PK_PATH}
+cat << EOF > ~/.ssh/config
+
+Host jumphost
+  HostName ${HOST}
+  User ${USER}
+  IdentityFile ${PK_PATH}
+
+  StrictHostKeyChecking no
+### Second jumphost. Only reachable via jumphost1.example.org
+Host ${BOSH_HOST}
+  HostName ${BOSH_HOST}
+  ProxyJump jumphost
+EOF
+fi
 
 ./bosh-disaster-recovery-acceptance-tests/scripts/_run_acceptance_tests.sh
 

--- a/ci/tasks/run-b-drats/task.yml
+++ b/ci/tasks/run-b-drats/task.yml
@@ -13,14 +13,8 @@ inputs:
   - name: terraform-state
     optional: true
 params:
-  JUMPBOX_VARS_STORE_PATH:
-  JUMPBOX_IP:
-  JUMPBOX_PRIVATE_KEY:
-  JUMPBOX_USER: jumpbox
   INTEGRATION_CONFIG_PATH: integration_config.json
-  SSH_ALIVE_INTERVAL: 30
   BBR_BINARY: bbr-binary-release/bbr-[0-9]*-linux-amd64
   GINKGO_TIMEOUT: 24h0m0s
-  SSHUTTLE_FLAGS:
 run:
   path: bosh-disaster-recovery-acceptance-tests/ci/tasks/run-b-drats/task.sh

--- a/runner/command_line_helpers.go
+++ b/runner/command_line_helpers.go
@@ -87,13 +87,27 @@ func RunCommandWithStream(description string, writer io.Writer, cmd string, args
 	fmt.Fprintln(writer, "")
 	return session
 }
-
+func getBoshAllProxy(config Config) string {
+	// ssh+socks5://ubuntu@34.72.88.156:22?private-key=/tmp/tmp.bBURxmHm5j
+	if config.Jumpbox.HostIsSet() {
+		keyPath, err := config.Jumpbox.WriteKeyFile()
+		if err != nil {
+			Fail("failed writing jumphost keyfile")
+		}
+		return fmt.Sprintf("BOSH_ALL_PROXY=ssh+socks5://%s:22?private-key=%s", config.Jumpbox.GetUserHost(), keyPath)
+	}
+	return ""
+}
 func getBoshBaseCommand(config Config) string {
-	return fmt.Sprintf("bosh "+
-		"--environment=%s "+
-		"--client=%s "+
-		"--client-secret=%s "+
-		"--ca-cert=%s ",
+
+	return fmt.Sprintf(
+		"%s "+
+			"bosh "+
+			"--environment=%s "+
+			"--client=%s "+
+			"--client-secret=%s "+
+			"--ca-cert=%s ",
+		getBoshAllProxy(config),
 		config.BOSH.Host,
 		config.BOSH.Client,
 		config.BOSH.ClientSecret,

--- a/runner/jumpbox.go
+++ b/runner/jumpbox.go
@@ -32,8 +32,12 @@ type jumpbox struct {
 func (j *jumpbox) HostIsSet() bool {
 	return j.host != ""
 }
+func (j *jumpbox) GetUserHost() string {
+	return fmt.Sprintf("%s@%s", j.user, j.host)
+}
+
 func (j *jumpbox) getSshBaseCommand() string {
-	keyPath, err := j.writeKeyFile()
+	keyPath, err := j.WriteKeyFile()
 	if err != nil {
 		Fail("failed writing jumphost keyfile")
 	}
@@ -48,7 +52,7 @@ func (j *jumpbox) getSshBaseCommand() string {
 	)
 }
 func (j *jumpbox) getScpBaseCommand(sourcePath, targetPath string) string {
-	keyPath, err := j.writeKeyFile()
+	keyPath, err := j.WriteKeyFile()
 	if err != nil {
 		Fail("failed writing jumphost keyfile")
 	}
@@ -80,7 +84,7 @@ func (j *jumpbox) Run(description string, config Config, args ...string) *gexec.
 
 	return RunBoshCommand(description, config, params...)
 }
-func (j *jumpbox) writeKeyFile() (string, error) {
+func (j *jumpbox) WriteKeyFile() (string, error) {
 	d, err := os.MkdirTemp("", "drats")
 	if err != nil {
 		return "", err
@@ -129,7 +133,7 @@ func (j *jumpbox) Cleanup(config Config) {
 		GinkgoWriter.Println("Jumpbox cleanup not needed")
 		return
 	}
-	if j.host != "" {
+	if j.host == "" {
 		By("cleaning up the jumpbox")
 		RunBoshCommandSuccessfullyWithFailureMessage("cleaning up the jumpbox", config, "-n", "-d", deployment, "delete-deployment")
 	}


### PR DESCRIPTION
920dd85e926664cf93a211f9356765b7c65d1ea6 added a feature where the jumphost could be set via the config file. this means that using sshuttle is unnecessary as all commands are executed on the jumpbox.