### PR TITLE
drats panic when no values for jumphost are provided

### DIFF
--- a/runner/artifactpath.go
+++ b/runner/artifactpath.go
@@ -60,7 +60,7 @@ func (l localArtifactPath) firstMatch(substr string) string {
 func newJumpboxArtifactPath(config Config) commonArtifactPath {
 	By("creating an artifact directory on the jumpbox")
 	session := config.Jumpbox.Run("make temporary directory", config, "mktemp", "-d")
-	if config.Jumpbox.HostIsSet() {
+	if config.Jumpbox != nil && config.Jumpbox.HostIsSet() {
 		tmpMatcher = tmpMatcherExistingJumpbox
 	}
 	matches := tmpMatcher.FindStringSubmatch(string(session.Out.Contents()))
@@ -93,7 +93,7 @@ func (l jumpboxArtifactPath) cleanup() {
 func (l jumpboxArtifactPath) firstMatch(substr string) string {
 	By("listing the contents of the artifact directory on the jumpbox")
 	session := l.config.Jumpbox.Run("list", l.config, "find", l.dir, "-maxdepth 1")
-	if l.config.Jumpbox.HostIsSet() {
+	if l.config.Jumpbox != nil && l.config.Jumpbox.HostIsSet() {
 		tmpMatcher = tmpMatcherExistingJumpbox
 	}
 	contents := tmpMatcher.FindAllStringSubmatch(string(session.Out.Contents()), -1)

--- a/runner/command_line_helpers.go
+++ b/runner/command_line_helpers.go
@@ -89,7 +89,7 @@ func RunCommandWithStream(description string, writer io.Writer, cmd string, args
 }
 func getBoshAllProxy(config Config) string {
 	// ssh+socks5://ubuntu@34.72.88.156:22?private-key=/tmp/tmp.bBURxmHm5j
-	if config.Jumpbox.HostIsSet() {
+	if config.Jumpbox != nil && config.Jumpbox.HostIsSet() {
 		keyPath, err := config.Jumpbox.WriteKeyFile()
 		if err != nil {
 			Fail("failed writing jumphost keyfile")


### PR DESCRIPTION
fix:
```
  [PANICKED] Test Panicked
  In [It] at: /tmp/build/02a90028/src/github.com/cloudfoundry/bosh-disaster-recovery-acceptance-tests/vendor/github.com/onsi/gomega/internal/async_assertion.go:321 @ 09/18/23 05:13:03.815

  runtime error: invalid memory address or nil pointer dereference

  Full Stack Trace
    github.com/onsi/gomega/internal.(*AsyncAssertion).buildActualPoller.func3.1()
    	/tmp/build/02a90028/src/github.com/cloudfoundry/bosh-disaster-recovery-acceptance-tests/vendor/github.com/onsi/gomega/internal/async_assertion.go:321 +0x1c5
    panic({0x929780?, 0xe4c980?})
    	/usr/local/go/src/runtime/panic.go:914 +0x21f
    github.com/cloudfoundry-incubator/bosh-disaster-recovery-acceptance-tests/runner.(*jumpbox).HostIsSet(...)
    	/tmp/build/02a90028/src/github.com/cloudfoundry/bosh-disaster-recovery-acceptance-tests/runner/jumpbox.go:33
    github.com/cloudfoundry-incubator/bosh-disaster-recovery-acceptance-tests/runner.getBoshAllProxy({{{0xc000015f50, 0xf}, {0xc000015e78, 0x7}, {0xc00002aba0, 0x16}, {0xc000015f62, 0x5}, {0xc00002ab70, 0x14}, ...}, ...})
    	/tmp/build/02a90028/src/github.com/cloudfoundry/bosh-disaster-recovery-acceptance-tests/runner/command_line_helpers.go:92 +0x1a
    github.com/cloudfoundry-incubator/bosh-disaster-recovery-acceptance-tests/runner.getBoshBaseCommand({{{0xc000015f50, 0xf}, {0xc000015e78, 0x7}, {0xc00002aba0, 0x16}, {0xc000015f62, 0x5}, {0xc00002ab70, 0x14}, ...}, ...})
```

when the jumphost isn't set at all, the code currently panics because it tries to run HostIsSet on a nil value. This causes a panic. Checking if the configs jumpbox field is nil before calling HostIsSet should avoid that.

Thanks for submitting a PR to B-DRATS.
