### PR TITLE
all bumpers should be serial

### DIFF
--- a/ci/pipelines/b-drats/pipeline.yml
+++ b/ci/pipelines/b-drats/pipeline.yml
@@ -294,6 +294,7 @@ jobs:
       action: release
 
 - name: bump-golang
+  serial: true
   plan:
   - in_parallel:
     - get: cryogenics-concourse-tasks
@@ -343,6 +344,7 @@ jobs:
         source-repo: b-drats-bump-output
 
 - name: bump-go-module
+  serial: true
   plan:
   - in_parallel:
     - get: daily-timer


### PR DESCRIPTION
they currently force push. That created issues when the same job got triggered twice ( for unknown reasons ) and job n-1 "overtook" job n ( n used a newer HEAD ) and force pushed over the changes made by n.
